### PR TITLE
Declare dependencies on cl-lib and Emacs 24.1

### DIFF
--- a/org-tfl.el
+++ b/org-tfl.el
@@ -18,7 +18,7 @@
 ;; Version: 0.3.0
 ;; Author: storax (David Zuber), <zuber [dot] david [at] gmx [dot] de>
 ;; URL: https://github.com/storax/org-tfl
-;; Package-Requires: ((org "0.16.2"))
+;; Package-Requires: ((org "0.16.2") (cl-lib "0.5") (emacs "24.1"))
 ;; Keywords: org, tfl
 
 ;;; Commentary:


### PR DESCRIPTION
Emacs 24.1 is required for pcase.

In connection with https://github.com/milkypostman/melpa/pull/3521
